### PR TITLE
Update policy_templates.json

### DIFF
--- a/docs/policy_templates_data/policy_templates.json
+++ b/docs/policy_templates_data/policy_templates.json
@@ -1207,6 +1207,23 @@
         ]
       }
     },
+    "EKSDescribePolicy": {
+      "Description": "Gives permission to describe or list Amazon EKS clusters",
+      "Parameters": {
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "eks:DescribeCluster",
+              "eks:ListClusters"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }
+    },
     "FirehoseCrudPolicy": {
       "Description": "Gives permission to create, write to, update, and delete a Kinesis Firehose Delivery Stream",
       "Parameters": {


### PR DESCRIPTION
- add EKSDescribePolicy - Gives permission to describe or list Amazon EKS clusters

*Issue #, if available:*

*Description of changes:*  [pahud/eks-lambda-drainer](https://github.com/pahud/eks-lambda-drainer) will require this policy template so that Lambda function can describe or list Amazon EKS clusters.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
